### PR TITLE
feat: correlation_id pass-through and shove:results emitter

### DIFF
--- a/cmd/shove/main.go
+++ b/cmd/shove/main.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/mattstrayer/shove/internal/queue"
 	"github.com/mattstrayer/shove/internal/queue/memory"
-	"github.com/mattstrayer/shove/internal/queue/redis"
+	queueredis "github.com/mattstrayer/shove/internal/queue/redis"
 	"github.com/mattstrayer/shove/internal/server"
 	"github.com/mattstrayer/shove/internal/services"
 	"github.com/mattstrayer/shove/internal/services/apns"
@@ -23,7 +23,44 @@ import (
 	"github.com/mattstrayer/shove/internal/services/telegram"
 	"github.com/mattstrayer/shove/internal/services/webhook"
 	"github.com/mattstrayer/shove/internal/services/webpush"
+	goredis "github.com/redis/go-redis/v9"
 )
+
+// apnsResultAdapter routes APNS envelopes to the queue/redis emitter.
+// A thin wrapper is required because services/apns declares its own
+// ResultEnvelope type to avoid importing queue/redis.
+type apnsResultAdapter struct{ inner *queueredis.ResultEmitter }
+
+func (a apnsResultAdapter) Emit(ctx context.Context, r apns.ResultEnvelope) error {
+	return a.inner.Emit(ctx, queueredis.Result{
+		CorrelationID: r.CorrelationID,
+		Service:       r.Service,
+		Status:        queueredis.ResultStatus(r.Status),
+		GatewayID:     r.GatewayID,
+		HTTPStatus:    r.HTTPStatus,
+		ErrorCode:     r.ErrorCode,
+		ErrorMessage:  r.ErrorMessage,
+		LatencyMS:     r.LatencyMS,
+		Timestamp:     r.Timestamp,
+	})
+}
+
+// fcmResultAdapter routes FCM envelopes to the queue/redis emitter.
+type fcmResultAdapter struct{ inner *queueredis.ResultEmitter }
+
+func (a fcmResultAdapter) Emit(ctx context.Context, r fcm.ResultEnvelope) error {
+	return a.inner.Emit(ctx, queueredis.Result{
+		CorrelationID: r.CorrelationID,
+		Service:       r.Service,
+		Status:        queueredis.ResultStatus(r.Status),
+		GatewayID:     r.GatewayID,
+		HTTPStatus:    r.HTTPStatus,
+		ErrorCode:     r.ErrorCode,
+		ErrorMessage:  r.ErrorMessage,
+		LatencyMS:     r.LatencyMS,
+		Timestamp:     r.Timestamp,
+	})
+}
 
 // from -> https://www.gmarik.info/blog/2019/12-factor-golang-flag-package/
 func LookupEnvOrString(key string, defaultVal string) string {
@@ -141,6 +178,7 @@ func main() {
 
 	var qf queue.QueueFactory
 	var fs queue.FeedbackStore
+	var resultEmitter *queueredis.ResultEmitter
 
 	if *redisHost == "" {
 		slog.Warn("REDIS_HOST not set, using non-persistent in-memory queue and feedback store")
@@ -149,15 +187,25 @@ func main() {
 	} else {
 		redisURL := buildRedisURL()
 		slog.Info("Using Redis queue", "host", *redisHost, "port", *redisPort, "db", *redisDB)
-		qf = redis.NewQueueFactory(redisURL)
+		qf = queueredis.NewQueueFactory(redisURL)
 
 		var err error
-		fs, err = redis.NewFeedbackStoreFromURL(redisURL)
+		fs, err = queueredis.NewFeedbackStoreFromURL(redisURL)
 		if err != nil {
 			slog.Error("Failed to create Redis feedback store", "error", err)
 			os.Exit(1)
 		}
 		slog.Info("Using Redis feedback store", "key", "shove:feedback")
+
+		// Build the results emitter from the same Redis connection params.
+		// Result events land on `shove:results`; the Vandal API drains them.
+		opt, err := goredis.ParseURL(redisURL)
+		if err != nil {
+			slog.Error("Failed to parse Redis URL for result emitter", "error", err)
+			os.Exit(1)
+		}
+		resultEmitter = queueredis.NewResultEmitter(goredis.NewClient(opt))
+		slog.Info("result emitter wired", "key", "shove:results")
 	}
 	s := server.NewServer(*apiAddr, qf, fs, *workerOnly)
 
@@ -172,6 +220,9 @@ func main() {
 		if err != nil {
 			logger.Error("Failed to initialize APNS", "error", err)
 			os.Exit(1)
+		}
+		if resultEmitter != nil {
+			apnsService.SetResultEmitter(apnsResultAdapter{inner: resultEmitter})
 		}
 		if err := s.AddService(apnsService, *apnsWorkers, services.SquashConfig{}); err != nil {
 			slog.Error("Failed to add APNS service", "error", err)
@@ -193,6 +244,9 @@ func main() {
 			logger.Error("Failed to initialize APNS sandbox", "error", err)
 			os.Exit(1)
 		}
+		if resultEmitter != nil {
+			apnsService.SetResultEmitter(apnsResultAdapter{inner: resultEmitter})
+		}
 		if err := s.AddService(apnsService, *apnsWorkers, services.SquashConfig{}); err != nil {
 			slog.Error("Failed to add APNS sandbox service", "error", err)
 			os.Exit(1)
@@ -212,6 +266,9 @@ func main() {
 		if err != nil {
 			slog.Error("Failed to setup FCM service", "error", err)
 			os.Exit(1)
+		}
+		if resultEmitter != nil {
+			fcmService.SetResultEmitter(fcmResultAdapter{inner: resultEmitter})
 		}
 		if err := s.AddService(fcmService, *fcmWorkers, services.SquashConfig{}); err != nil {
 			slog.Error("Failed to add FCM service", "error", err)

--- a/go.mod
+++ b/go.mod
@@ -5,10 +5,12 @@ go 1.24.0
 require (
 	firebase.google.com/go/v4 v4.13.0
 	github.com/SherClockHolmes/webpush-go v1.2.0
+	github.com/alicebob/miniredis/v2 v2.38.0
 	github.com/jordan-wright/email v4.0.1-0.20210109023952-943e75fe5223+incompatible
 	github.com/prometheus/client_golang v1.14.0
 	github.com/redis/go-redis/v9 v9.5.1
 	github.com/sideshow/apns2 v0.25.0
+	google.golang.org/api v0.189.0
 )
 
 require (
@@ -39,6 +41,7 @@ require (
 	github.com/prometheus/client_model v0.3.0 // indirect
 	github.com/prometheus/common v0.37.0 // indirect
 	github.com/prometheus/procfs v0.8.0 // indirect
+	github.com/yuin/gopher-lua v1.1.1 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.49.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
@@ -52,7 +55,6 @@ require (
 	golang.org/x/sys v0.30.0 // indirect
 	golang.org/x/text v0.22.0 // indirect
 	golang.org/x/time v0.5.0 // indirect
-	google.golang.org/api v0.189.0 // indirect
 	google.golang.org/appengine/v2 v2.0.2 // indirect
 	google.golang.org/genproto v0.0.0-20240722135656-d784300faade // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240722135656-d784300faade // indirect

--- a/go.sum
+++ b/go.sum
@@ -61,6 +61,8 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/alecthomas/units v0.0.0-20201120081800-1786d5ef83d4/go.mod h1:OMCwj8VM1Kc9e19TLln2VL61YJF0x1XFtfdL4JdbSyE=
+github.com/alicebob/miniredis/v2 v2.38.0 h1:nZAzCR+Lj+Vxk4ZXzm2NuKq2O33RXj1XxJ2e2uP9jiw=
+github.com/alicebob/miniredis/v2 v2.38.0/go.mod h1:TcL7YfarKPGDAthEtl5NBeHZfeUQj6OXMm/+iu5cLMM=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
@@ -269,6 +271,8 @@ github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
+github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
+github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=

--- a/internal/queue/feedback.go
+++ b/internal/queue/feedback.go
@@ -36,4 +36,3 @@ type FeedbackStore interface {
 type FeedbackStoreFactory interface {
 	NewFeedbackStore() (FeedbackStore, error)
 }
-

--- a/internal/queue/memory/feedback.go
+++ b/internal/queue/memory/feedback.go
@@ -84,4 +84,3 @@ func (s *FeedbackStore) Close() error {
 
 // Ensure FeedbackStore implements queue.FeedbackStore
 var _ queue.FeedbackStore = (*FeedbackStore)(nil)
-

--- a/internal/queue/redis/feedback.go
+++ b/internal/queue/redis/feedback.go
@@ -129,4 +129,3 @@ func (s *FeedbackStore) Close() error {
 
 // Ensure FeedbackStore implements queue.FeedbackStore
 var _ queue.FeedbackStore = (*FeedbackStore)(nil)
-

--- a/internal/queue/redis/miniredis_helper_test.go
+++ b/internal/queue/redis/miniredis_helper_test.go
@@ -1,0 +1,16 @@
+package redis
+
+import "github.com/alicebob/miniredis/v2"
+
+type miniWrap struct{ s *miniredis.Miniredis }
+
+func (m *miniWrap) addr() string { return m.s.Addr() }
+func (m *miniWrap) close()       { m.s.Close() }
+
+func startMiniredis() (*miniWrap, error) {
+	s, err := miniredis.Run()
+	if err != nil {
+		return nil, err
+	}
+	return &miniWrap{s: s}, nil
+}

--- a/internal/queue/redis/redis.go
+++ b/internal/queue/redis/redis.go
@@ -48,9 +48,9 @@ func NewQueueFactory(redisURL string) queue.QueueFactory {
 	log.Printf("Connecting to Redis at: %s", opt.Addr)
 
 	// Configure connection pool settings
-	opt.PoolSize = 50                  // Increase from default 10
-	opt.MinIdleConns = 10              // Maintain some minimum idle connections
-	opt.PoolTimeout = time.Second * 30 // Increase timeout for getting connection from pool
+	opt.PoolSize = 50                   // Increase from default 10
+	opt.MinIdleConns = 10               // Maintain some minimum idle connections
+	opt.PoolTimeout = time.Second * 30  // Increase timeout for getting connection from pool
 	opt.ReadTimeout = 10 * time.Second  // Timeout for read operations
 	opt.WriteTimeout = 10 * time.Second // Timeout for write operations
 	opt.DialTimeout = 5 * time.Second   // Timeout for establishing connections
@@ -125,7 +125,7 @@ func (q *redisQueue) Get(ctx context.Context) (queue.QueuedMessage, error) {
 			}
 
 			err := result.Err()
-			
+
 			// redis.Nil is expected when BRPop times out (no messages available)
 			// This is not an error, just continue waiting
 			if err == redis.Nil {

--- a/internal/queue/redis/results.go
+++ b/internal/queue/redis/results.go
@@ -1,0 +1,57 @@
+package redis
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// resultsKey is the Redis list shove pushes per-send results onto.
+const resultsKey = "shove:results"
+
+// ResultStatus enumerates the three terminal states for a push attempt.
+type ResultStatus string
+
+const (
+	ResultStatusDelivered ResultStatus = "delivered"
+	ResultStatusFailed    ResultStatus = "failed"
+	ResultStatusInvalid   ResultStatus = "invalid"
+)
+
+// Result is the envelope shove writes onto shove:results after each
+// APNS/FCM round-trip. Shape is service-agnostic.
+type Result struct {
+	CorrelationID string       `json:"correlation_id"`
+	Service       string       `json:"service"`
+	Status        ResultStatus `json:"status"`
+	GatewayID     string       `json:"gateway_id,omitempty"`
+	HTTPStatus    int          `json:"http_status,omitempty"`
+	ErrorCode     string       `json:"error_code,omitempty"`
+	ErrorMessage  string       `json:"error_message,omitempty"`
+	LatencyMS     int64        `json:"latency_ms,omitempty"`
+	Timestamp     int64        `json:"timestamp"`
+}
+
+// ResultEmitter LPUSHes Result envelopes onto shove:results.
+// It mirrors FeedbackStore's shape but is intentionally a separate type:
+// results have a distinct schema and lifecycle from token feedback.
+type ResultEmitter struct {
+	client *redis.Client
+}
+
+// NewResultEmitter wraps an existing Redis client.
+func NewResultEmitter(client *redis.Client) *ResultEmitter {
+	return &ResultEmitter{client: client}
+}
+
+// Emit writes one result envelope. Safe to call with an empty
+// correlation_id — callers (handlers) should guard, but if a zero-value
+// envelope gets through we still write it so the operator notices.
+func (e *ResultEmitter) Emit(ctx context.Context, r Result) error {
+	data, err := json.Marshal(r)
+	if err != nil {
+		return err
+	}
+	return e.client.LPush(ctx, resultsKey, data).Err()
+}

--- a/internal/queue/redis/results_test.go
+++ b/internal/queue/redis/results_test.go
@@ -1,0 +1,83 @@
+package redis
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/redis/go-redis/v9"
+)
+
+func newMiniRedis(t *testing.T) *redis.Client {
+	t.Helper()
+	s, err := startMiniredis()
+	if err != nil {
+		t.Skipf("miniredis unavailable: %v", err)
+	}
+	t.Cleanup(s.close)
+	return redis.NewClient(&redis.Options{Addr: s.addr()})
+}
+
+func TestResultEmitter_EmitWritesEnvelope(t *testing.T) {
+	client := newMiniRedis(t)
+	emitter := NewResultEmitter(client)
+	ctx := context.Background()
+
+	res := Result{
+		CorrelationID: "9b3f-uuid",
+		Service:       "apns",
+		Status:        ResultStatusDelivered,
+		GatewayID:     "abc-apns-id",
+		HTTPStatus:    200,
+		LatencyMS:     87,
+		Timestamp:     1716200000,
+	}
+	if err := emitter.Emit(ctx, res); err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+
+	got, err := client.LRange(ctx, "shove:results", 0, -1).Result()
+	if err != nil {
+		t.Fatalf("LRange: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(got))
+	}
+	var decoded Result
+	if err := json.Unmarshal([]byte(got[0]), &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if decoded != res {
+		t.Fatalf("round-trip mismatch:\n got  %+v\n want %+v", decoded, res)
+	}
+}
+
+func TestResultEmitter_EmitOmitsEmptyOptionalFields(t *testing.T) {
+	client := newMiniRedis(t)
+	emitter := NewResultEmitter(client)
+	ctx := context.Background()
+
+	if err := emitter.Emit(ctx, Result{
+		CorrelationID: "uuid",
+		Service:       "fcm",
+		Status:        ResultStatusDelivered,
+		Timestamp:     1,
+	}); err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	got, _ := client.LRange(ctx, "shove:results", 0, -1).Result()
+	for _, field := range []string{"gateway_id", "error_code", "error_message", "http_status", "latency_ms"} {
+		if bytesContains(got[0], field) {
+			t.Fatalf("expected %q to be omitted; payload: %s", field, got[0])
+		}
+	}
+}
+
+func bytesContains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/services/apns/apns.go
+++ b/internal/services/apns/apns.go
@@ -1,6 +1,7 @@
 package apns
 
 import (
+	"context"
 	"crypto/ecdsa"
 	"crypto/x509"
 	"encoding/base64"
@@ -17,6 +18,12 @@ import (
 	"github.com/sideshow/apns2/token"
 )
 
+// apns2Pusher abstracts the subset of *apns2.Client used by pushWithClient,
+// enabling fake clients in tests.
+type apns2Pusher interface {
+	Push(*apns2.Notification) (*apns2.Response, error)
+}
+
 // APNS ...
 type APNS struct {
 	production bool
@@ -24,7 +31,11 @@ type APNS struct {
 	keyID      string
 	teamID     string
 	authKey    *ecdsa.PrivateKey
+	emitter    ResultEmitter
 }
+
+// SetResultEmitter wires an emitter used to publish delivery results.
+func (apns *APNS) SetResultEmitter(e ResultEmitter) { apns.emitter = e }
 
 // NewAPNS creates a new APNS service from a file path
 func NewAPNS(authKeyPath, keyID, teamID string, production bool, log *slog.Logger) (apns *APNS, err error) {
@@ -120,16 +131,28 @@ func (apns *APNS) SquashAndPushMessage(client services.PumpClient, smsgs []servi
 	panic("not implemented")
 }
 
-func (apns *APNS) PushMessage(pclient services.PumpClient, smsg services.ServiceMessage, fc services.FeedbackCollector) (status services.PushStatus) {
+func (apns *APNS) PushMessage(pclient services.PumpClient, smsg services.ServiceMessage, fc services.FeedbackCollector) services.PushStatus {
 	client := pclient.(*apns2.Client)
-	notif := smsg.(apnsNotification)
+	return apns.pushWithClient(client, smsg.(apnsNotification), fc)
+}
+
+func (apns *APNS) pushWithClient(client apns2Pusher, notif apnsNotification, fc services.FeedbackCollector) services.PushStatus {
 	t := time.Now()
 	resp, err := client.Push(notif.notification)
-	duration := time.Now().Sub(t)
+	duration := time.Since(t)
 	sent := false
+	var status services.PushStatus
+	var envelope ResultEnvelope
+	envelope.CorrelationID = notif.correlationID
+	envelope.Service = apns.ID()
+	envelope.LatencyMS = duration.Milliseconds()
+	envelope.Timestamp = time.Now().Unix()
+
 	if err != nil {
 		apns.log.Error("Push message failed", "error", err)
 		status = services.PushStatusTempFail
+		envelope.Status = ResultStatusFailed
+		envelope.ErrorMessage = err.Error()
 	} else {
 		reason := resp.Reason
 		if reason == "" {
@@ -137,18 +160,35 @@ func (apns *APNS) PushMessage(pclient services.PumpClient, smsg services.Service
 		}
 		apns.log.Info("Pushed", "reason", reason, "duration", duration)
 		sent = resp.Sent()
+		envelope.GatewayID = resp.ApnsID
+		envelope.HTTPStatus = resp.StatusCode
+		envelope.ErrorCode = resp.Reason
+
 		if resp.Reason == apns2.ReasonBadDeviceToken || resp.Reason == apns2.ReasonUnregistered {
 			fc.TokenInvalid(apns.ID(), notif.notification.DeviceToken)
-		}
-		retry := resp.StatusCode >= 500
-		if sent {
+			envelope.Status = ResultStatusInvalid
+			status = services.PushStatusHardFail
+		} else if sent {
+			envelope.Status = ResultStatusDelivered
 			status = services.PushStatusSuccess
-		} else if retry {
+		} else if resp.StatusCode >= 500 {
+			envelope.Status = ResultStatusFailed
 			status = services.PushStatusTempFail
 		} else {
+			envelope.Status = ResultStatusFailed
 			status = services.PushStatusHardFail
 		}
 	}
 	fc.CountPush(apns.ID(), sent, duration)
-	return
+	apns.emitResult(envelope)
+	return status
+}
+
+func (apns *APNS) emitResult(env ResultEnvelope) {
+	if apns.emitter == nil || env.CorrelationID == "" {
+		return
+	}
+	if err := apns.emitter.Emit(context.Background(), env); err != nil {
+		apns.log.Error("Failed to emit result", "error", err, "correlation_id", env.CorrelationID)
+	}
 }

--- a/internal/services/apns/apns_integration_test.go
+++ b/internal/services/apns/apns_integration_test.go
@@ -1,0 +1,108 @@
+package apns_test
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	goredis "github.com/redis/go-redis/v9"
+	apns2 "github.com/sideshow/apns2"
+
+	queueredis "github.com/mattstrayer/shove/internal/queue/redis"
+	"github.com/mattstrayer/shove/internal/services/apns"
+)
+
+// adapter bridges apns.ResultEmitter -> queueredis.ResultEmitter.
+type adapter struct{ inner *queueredis.ResultEmitter }
+
+func (a adapter) Emit(ctx context.Context, r apns.ResultEnvelope) error {
+	return a.inner.Emit(ctx, queueredis.Result{
+		CorrelationID: r.CorrelationID,
+		Service:       r.Service,
+		Status:        queueredis.ResultStatus(r.Status),
+		GatewayID:     r.GatewayID,
+		HTTPStatus:    r.HTTPStatus,
+		ErrorCode:     r.ErrorCode,
+		ErrorMessage:  r.ErrorMessage,
+		LatencyMS:     r.LatencyMS,
+		Timestamp:     r.Timestamp,
+	})
+}
+
+type stubClient struct {
+	resp *apns2.Response
+	err  error
+}
+
+func (s *stubClient) Push(_ *apns2.Notification) (*apns2.Response, error) {
+	return s.resp, s.err
+}
+
+type noopFC struct{}
+
+func (noopFC) TokenInvalid(_, _ string)                    {}
+func (noopFC) ReplaceToken(_, _, _ string)                 {}
+func (noopFC) CountPush(_ string, _ bool, _ time.Duration) {}
+
+func TestAPNS_EndToEnd_ResultsEmitted(t *testing.T) {
+	mr, err := miniredis.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mr.Close()
+	client := goredis.NewClient(&goredis.Options{Addr: mr.Addr()})
+	emitter := queueredis.NewResultEmitter(client)
+
+	cases := []struct {
+		name       string
+		corr       string
+		resp       *apns2.Response
+		wantStatus queueredis.ResultStatus
+	}{
+		{"delivered", "corr-1", &apns2.Response{StatusCode: 200, ApnsID: "gw-1"}, queueredis.ResultStatusDelivered},
+		{"invalid", "corr-2", &apns2.Response{StatusCode: 410, Reason: apns2.ReasonUnregistered}, queueredis.ResultStatusInvalid},
+		{"failed", "corr-3", &apns2.Response{StatusCode: 503, Reason: "ServiceUnavailable"}, queueredis.ResultStatusFailed},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mr.FlushAll()
+			a := apns.NewAPNSForTest(slog.New(slog.NewTextHandler(os.Stderr, nil)))
+			a.SetResultEmitter(adapter{inner: emitter})
+
+			body, _ := json.Marshal(map[string]any{
+				"token":          "tok",
+				"correlation_id": tc.corr,
+				"headers":        map[string]any{"apns-topic": "app.vandal.app"},
+				"payload":        map[string]any{"aps": map[string]any{"alert": "hi"}},
+			})
+			smsg, err := a.ConvertMessage(body)
+			if err != nil {
+				t.Fatalf("ConvertMessage: %v", err)
+			}
+
+			apns.PushForTest(a, &stubClient{resp: tc.resp}, smsg, noopFC{})
+
+			items, err := client.LRange(context.Background(), "shove:results", 0, -1).Result()
+			if err != nil {
+				t.Fatalf("LRange: %v", err)
+			}
+			if len(items) != 1 {
+				t.Fatalf("expected 1 result, got %d", len(items))
+			}
+			var got queueredis.Result
+			if err := json.Unmarshal([]byte(items[0]), &got); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if got.Status != tc.wantStatus {
+				t.Fatalf("status = %q want %q", got.Status, tc.wantStatus)
+			}
+			if got.CorrelationID != tc.corr {
+				t.Fatalf("correlation_id = %q want %q", got.CorrelationID, tc.corr)
+			}
+		})
+	}
+}

--- a/internal/services/apns/apns_results_test.go
+++ b/internal/services/apns/apns_results_test.go
@@ -1,0 +1,122 @@
+package apns
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/sideshow/apns2"
+)
+
+type fakeEmitter struct{ emitted []ResultEnvelope }
+
+func (f *fakeEmitter) Emit(ctx context.Context, r ResultEnvelope) error {
+	f.emitted = append(f.emitted, r)
+	return nil
+}
+
+type fakeFC struct{ invalid []string }
+
+func (f *fakeFC) TokenInvalid(_, t string)                    { f.invalid = append(f.invalid, t) }
+func (f *fakeFC) ReplaceToken(_, _, _ string)                 {}
+func (f *fakeFC) CountPush(_ string, _ bool, _ time.Duration) {}
+
+type fakeAPNSClient struct {
+	resp *apns2.Response
+	err  error
+}
+
+func (f *fakeAPNSClient) Push(_ *apns2.Notification) (*apns2.Response, error) {
+	return f.resp, f.err
+}
+
+func TestEmitResultFromAPNSResponse(t *testing.T) {
+	cases := []struct {
+		name       string
+		resp       *apns2.Response
+		err        error
+		corr       string
+		wantStatus ResultStatus
+		wantEmit   bool
+	}{
+		{
+			name:       "delivered 200",
+			resp:       &apns2.Response{StatusCode: 200, ApnsID: "gw-id"},
+			corr:       "uuid-1",
+			wantStatus: ResultStatusDelivered,
+			wantEmit:   true,
+		},
+		{
+			name:       "invalid BadDeviceToken",
+			resp:       &apns2.Response{StatusCode: 400, Reason: apns2.ReasonBadDeviceToken},
+			corr:       "uuid-2",
+			wantStatus: ResultStatusInvalid,
+			wantEmit:   true,
+		},
+		{
+			name:       "invalid Unregistered",
+			resp:       &apns2.Response{StatusCode: 410, Reason: apns2.ReasonUnregistered},
+			corr:       "uuid-3",
+			wantStatus: ResultStatusInvalid,
+			wantEmit:   true,
+		},
+		{
+			name:       "failed 503",
+			resp:       &apns2.Response{StatusCode: 503, Reason: "ServiceUnavailable"},
+			corr:       "uuid-4",
+			wantStatus: ResultStatusFailed,
+			wantEmit:   true,
+		},
+		{
+			name:       "transport error",
+			err:        context.DeadlineExceeded,
+			corr:       "uuid-5",
+			wantStatus: ResultStatusFailed,
+			wantEmit:   true,
+		},
+		{
+			name:     "no correlation id - no emit",
+			resp:     &apns2.Response{StatusCode: 200, ApnsID: "gw-id"},
+			corr:     "",
+			wantEmit: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fe := &fakeEmitter{}
+			fc := &fakeFC{}
+			a := &APNS{
+				log:     slog.New(slog.NewTextHandler(os.Stderr, nil)),
+				emitter: fe,
+			}
+			notif := apnsNotification{
+				notification:  &apns2.Notification{DeviceToken: "tok"},
+				correlationID: tc.corr,
+			}
+			a.pushWithClient(&fakeAPNSClient{resp: tc.resp, err: tc.err}, notif, fc)
+
+			if !tc.wantEmit {
+				if len(fe.emitted) != 0 {
+					t.Fatalf("expected no emit, got %+v", fe.emitted)
+				}
+				return
+			}
+			if len(fe.emitted) != 1 {
+				t.Fatalf("expected 1 emit, got %d", len(fe.emitted))
+			}
+			got := fe.emitted[0]
+			if got.Status != tc.wantStatus {
+				t.Fatalf("status = %q want %q", got.Status, tc.wantStatus)
+			}
+			if got.CorrelationID != tc.corr {
+				t.Fatalf("correlationID = %q want %q", got.CorrelationID, tc.corr)
+			}
+			if got.Service != "apns" && got.Service != "apns-sandbox" {
+				t.Fatalf("unexpected service: %q", got.Service)
+			}
+		})
+	}
+}

--- a/internal/services/apns/export_test.go
+++ b/internal/services/apns/export_test.go
@@ -1,0 +1,18 @@
+package apns
+
+import (
+	"log/slog"
+
+	"github.com/mattstrayer/shove/internal/services"
+)
+
+// NewAPNSForTest constructs an APNS struct with only the logger set, for
+// tests that drive the handler with a fake apns2Pusher.
+func NewAPNSForTest(log *slog.Logger) *APNS {
+	return &APNS{log: log}
+}
+
+// PushForTest exposes pushWithClient to package-external tests.
+func PushForTest(a *APNS, client apns2Pusher, smsg services.ServiceMessage, fc services.FeedbackCollector) services.PushStatus {
+	return a.pushWithClient(client, smsg.(apnsNotification), fc)
+}

--- a/internal/services/apns/message.go
+++ b/internal/services/apns/message.go
@@ -10,13 +10,15 @@ import (
 )
 
 type apnsMessage struct {
-	Token   string                     `json:"token"`
-	Headers map[string]json.RawMessage `json:"headers,omitempty"`
-	Payload json.RawMessage            `json:"payload,omitempty"`
+	Token         string                     `json:"token"`
+	CorrelationID string                     `json:"correlation_id,omitempty"`
+	Headers       map[string]json.RawMessage `json:"headers,omitempty"`
+	Payload       json.RawMessage            `json:"payload,omitempty"`
 }
 
 type apnsNotification struct {
-	notification *apns2.Notification
+	notification  *apns2.Notification
+	correlationID string
 }
 
 func (notif apnsNotification) GetSquashKey() string {
@@ -68,7 +70,7 @@ func (apns *APNS) ConvertMessage(data []byte) (smsg services.ServiceMessage, err
 		notif.Expiration = time.Unix(epoch, 0)
 	}
 	notif.Payload = msg.Payload
-	smsg = apnsNotification{notification: notif}
+	smsg = apnsNotification{notification: notif, correlationID: msg.CorrelationID}
 	return
 }
 

--- a/internal/services/apns/message_test.go
+++ b/internal/services/apns/message_test.go
@@ -1,6 +1,8 @@
 package apns
 
 import (
+	"bytes"
+	"encoding/json"
 	"log/slog"
 	"os"
 	"testing"
@@ -49,5 +51,27 @@ func TestConvertMessage_CorrelationID(t *testing.T) {
 				t.Fatalf("correlationID = %q, want %q", n.correlationID, tc.wantCorr)
 			}
 		})
+	}
+}
+
+func TestConvertMessage_PayloadDoesNotContainCorrelationID(t *testing.T) {
+	a := newTestAPNS(t)
+	body := `{
+		"token": "abc",
+		"correlation_id": "9b3f-uuid",
+		"headers": {"apns-topic": "app.vandal.app"},
+		"payload": {"aps":{"alert":"hi"}}
+	}`
+	smsg, err := a.ConvertMessage([]byte(body))
+	if err != nil {
+		t.Fatalf("ConvertMessage: %v", err)
+	}
+	n := smsg.(apnsNotification)
+	raw, err := json.Marshal(n.notification.Payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	if bytes.Contains(raw, []byte("correlation_id")) {
+		t.Fatalf("forwarded payload contains correlation_id: %s", raw)
 	}
 }

--- a/internal/services/apns/message_test.go
+++ b/internal/services/apns/message_test.go
@@ -1,0 +1,53 @@
+package apns
+
+import (
+	"log/slog"
+	"os"
+	"testing"
+)
+
+func newTestAPNS(t *testing.T) *APNS {
+	t.Helper()
+	return &APNS{log: slog.New(slog.NewTextHandler(os.Stderr, nil))}
+}
+
+func TestConvertMessage_CorrelationID(t *testing.T) {
+	cases := []struct {
+		name     string
+		body     string
+		wantCorr string
+	}{
+		{
+			name: "with correlation_id",
+			body: `{
+				"token": "abc",
+				"correlation_id": "9b3f-uuid",
+				"headers": {"apns-topic": "app.vandal.app"},
+				"payload": {"aps":{"alert":"hi"}}
+			}`,
+			wantCorr: "9b3f-uuid",
+		},
+		{
+			name: "without correlation_id",
+			body: `{
+				"token": "abc",
+				"headers": {"apns-topic": "app.vandal.app"},
+				"payload": {"aps":{"alert":"hi"}}
+			}`,
+			wantCorr: "",
+		},
+	}
+	a := newTestAPNS(t)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			smsg, err := a.ConvertMessage([]byte(tc.body))
+			if err != nil {
+				t.Fatalf("ConvertMessage: %v", err)
+			}
+			n := smsg.(apnsNotification)
+			if n.correlationID != tc.wantCorr {
+				t.Fatalf("correlationID = %q, want %q", n.correlationID, tc.wantCorr)
+			}
+		})
+	}
+}

--- a/internal/services/apns/results.go
+++ b/internal/services/apns/results.go
@@ -1,0 +1,33 @@
+package apns
+
+import "context"
+
+// ResultStatus mirrors queueredis.ResultStatus but is redeclared locally
+// to keep the services/apns package free of a direct queue/redis import.
+// The bridge type is converted at the seam in cmd/.
+type ResultStatus string
+
+const (
+	ResultStatusDelivered ResultStatus = "delivered"
+	ResultStatusFailed    ResultStatus = "failed"
+	ResultStatusInvalid   ResultStatus = "invalid"
+)
+
+// ResultEnvelope is the in-package shape; cmd wires it to queue/redis.Result.
+type ResultEnvelope struct {
+	CorrelationID string
+	Service       string
+	Status        ResultStatus
+	GatewayID     string
+	HTTPStatus    int
+	ErrorCode     string
+	ErrorMessage  string
+	LatencyMS     int64
+	Timestamp     int64
+}
+
+// ResultEmitter is the abstraction APNS uses to publish results.
+// cmd injects an adapter that forwards to queue/redis.ResultEmitter.
+type ResultEmitter interface {
+	Emit(ctx context.Context, r ResultEnvelope) error
+}

--- a/internal/services/fcm/fcm.go
+++ b/internal/services/fcm/fcm.go
@@ -19,8 +19,17 @@ import (
 
 // FCM ...
 type FCM struct {
-	client *messaging.Client
-	log    *slog.Logger
+	client  *messaging.Client
+	log     *slog.Logger
+	emitter ResultEmitter
+}
+
+// SetResultEmitter wires a ResultEmitter to receive per-send result envelopes.
+func (fcm *FCM) SetResultEmitter(e ResultEmitter) { fcm.emitter = e }
+
+// fcmSender abstracts *messaging.Client for testing.
+type fcmSender interface {
+	Send(ctx context.Context, m *messaging.Message) (string, error)
 }
 
 // NewFCM creates a new FCM service using GOOGLE_APPLICATION_CREDENTIALS file path
@@ -124,60 +133,109 @@ func (fcm *FCM) SquashAndPushMessage(services.PumpClient, []services.ServiceMess
 }
 
 func (fcm *FCM) PushMessage(pclient services.PumpClient, smsg services.ServiceMessage, fc services.FeedbackCollector) services.PushStatus {
-	msg := smsg.(fcmMessage)
+	return fcm.sendWithClient(fcm.client, smsg.(fcmMessage), fc)
+}
+
+func (fcm *FCM) sendWithClient(sender fcmSender, msg fcmMessage, fc services.FeedbackCollector) services.PushStatus {
 	startedAt := time.Now()
 
 	message := messaging.Message{}
-	err := json.Unmarshal(msg.rawData, &message)
-	if err != nil {
+	if err := json.Unmarshal(msg.rawData, &message); err != nil {
 		fcm.log.Error("error unmarshalling message", "error", err)
+		fcm.emitFailure(msg, "unmarshal_error", err.Error(), 0, time.Since(startedAt))
 		return services.PushStatusHardFail
 	}
-
 	message.Token = msg.To
 
-	var success bool
+	gatewayID, err := sender.Send(context.Background(), &message)
+	duration := time.Since(startedAt)
+	fcm.log.Info("Sending", "gateway_id", gatewayID, "error", err)
 
-	// Send a message to the device corresponding to the provided
-	// registration token.
-	response, err := fcm.client.Send(context.Background(), &message)
-
-	fcm.log.Info("Sending", "response", response, "error", err)
 	if err != nil {
 		fcm.log.Error("sending failed", "error", err)
+
+		status := ResultStatusFailed
+		var pushStatus services.PushStatus
 
 		// Only define conditions where we need to hard fail.
 		// all others will be temp failed by default
 		// https://github.com/firebase/firebase-admin-go/blob/master/internal/errors.go#L68
-		if errorutils.IsInvalidArgument(err) {
-			return services.PushStatusHardFail
-		}
-
-		if errorutils.IsDataLoss(err) {
-			return services.PushStatusHardFail
-		}
-
-		if errorutils.IsNotFound(err) {
+		switch {
+		case errorutils.IsNotFound(err):
 			// you should remove the registration ID from your
 			// server database because the application was
 			// uninstalled from the device or it does not have a
 			// broadcast receiver configured to receive
 			// com.google.android.c2dm.intent.RECEIVE intents.
 			fc.TokenInvalid(fcm.ID(), msg.To)
-			return services.PushStatusHardFail
+			status = ResultStatusInvalid
+			pushStatus = services.PushStatusHardFail
+		case errorutils.IsInvalidArgument(err):
+			status = ResultStatusInvalid
+			pushStatus = services.PushStatusHardFail
+		case errorutils.IsDataLoss(err):
+			pushStatus = services.PushStatusHardFail
+		default:
+			pushStatus = services.PushStatusTempFail
 		}
 
-		return services.PushStatusTempFail
+		fc.CountPush(fcm.ID(), false, duration)
+		fcm.emitResult(ResultEnvelope{
+			CorrelationID: msg.CorrelationID,
+			Service:       fcm.ID(),
+			Status:        status,
+			ErrorCode:     errorCodeFor(err),
+			ErrorMessage:  err.Error(),
+			LatencyMS:     duration.Milliseconds(),
+			Timestamp:     time.Now().Unix(),
+		})
+		return pushStatus
 	}
 
-	duration := time.Since(startedAt)
-
-	defer func() {
-		fc.CountPush(fcm.ID(), success, duration)
-	}()
-
+	fc.CountPush(fcm.ID(), true, duration)
 	fcm.log.Info("Pushed", "duration", duration)
-
-	success = true
+	fcm.emitResult(ResultEnvelope{
+		CorrelationID: msg.CorrelationID,
+		Service:       fcm.ID(),
+		Status:        ResultStatusDelivered,
+		GatewayID:     gatewayID,
+		HTTPStatus:    http.StatusOK,
+		LatencyMS:     duration.Milliseconds(),
+		Timestamp:     time.Now().Unix(),
+	})
 	return services.PushStatusSuccess
+}
+
+func errorCodeFor(err error) string {
+	switch {
+	case errorutils.IsNotFound(err):
+		return "UNREGISTERED"
+	case errorutils.IsInvalidArgument(err):
+		return "INVALID_ARGUMENT"
+	case errorutils.IsDataLoss(err):
+		return "DATA_LOSS"
+	}
+	return "INTERNAL"
+}
+
+func (fcm *FCM) emitResult(env ResultEnvelope) {
+	if fcm.emitter == nil || env.CorrelationID == "" {
+		return
+	}
+	if err := fcm.emitter.Emit(context.Background(), env); err != nil {
+		fcm.log.Error("Failed to emit result", "error", err, "correlation_id", env.CorrelationID)
+	}
+}
+
+func (fcm *FCM) emitFailure(msg fcmMessage, code, message string, httpStatus int, dur time.Duration) {
+	fcm.emitResult(ResultEnvelope{
+		CorrelationID: msg.CorrelationID,
+		Service:       fcm.ID(),
+		Status:        ResultStatusFailed,
+		ErrorCode:     code,
+		ErrorMessage:  message,
+		HTTPStatus:    httpStatus,
+		LatencyMS:     dur.Milliseconds(),
+		Timestamp:     time.Now().Unix(),
+	})
 }

--- a/internal/services/fcm/fcm_results_test.go
+++ b/internal/services/fcm/fcm_results_test.go
@@ -1,0 +1,97 @@
+package fcm
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"firebase.google.com/go/v4/messaging"
+)
+
+type fakeEmitter struct{ emitted []ResultEnvelope }
+
+func (f *fakeEmitter) Emit(_ context.Context, r ResultEnvelope) error {
+	f.emitted = append(f.emitted, r)
+	return nil
+}
+
+type fakeFC struct{ invalid []string }
+
+func (f *fakeFC) TokenInvalid(_, t string)                    { f.invalid = append(f.invalid, t) }
+func (f *fakeFC) ReplaceToken(_, _, _ string)                 {}
+func (f *fakeFC) CountPush(_ string, _ bool, _ time.Duration) {}
+
+type fakeSender struct {
+	id  string
+	err error
+}
+
+func (f *fakeSender) Send(_ context.Context, _ *messaging.Message) (string, error) {
+	return f.id, f.err
+}
+
+func TestEmitResultFromFCMResponse(t *testing.T) {
+	cases := []struct {
+		name       string
+		sender     *fakeSender
+		corr       string
+		wantStatus ResultStatus
+		wantEmit   bool
+	}{
+		{
+			name:       "delivered",
+			sender:     &fakeSender{id: "projects/p/messages/abc"},
+			corr:       "uuid-1",
+			wantStatus: ResultStatusDelivered,
+			wantEmit:   true,
+		},
+		{
+			name:       "failed transport",
+			sender:     &fakeSender{err: errors.New("connection refused")},
+			corr:       "uuid-2",
+			wantStatus: ResultStatusFailed,
+			wantEmit:   true,
+		},
+		{
+			name:     "no correlation id - no emit",
+			sender:   &fakeSender{id: "x"},
+			corr:     "",
+			wantEmit: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fe := &fakeEmitter{}
+			fc := &fakeFC{}
+			f := &FCM{
+				log:     slog.New(slog.NewTextHandler(os.Stderr, nil)),
+				emitter: fe,
+			}
+			msg := fcmMessage{
+				To:            "tok",
+				CorrelationID: tc.corr,
+				rawData:       []byte(`{"to":"tok"}`),
+			}
+			f.sendWithClient(tc.sender, msg, fc)
+			if !tc.wantEmit {
+				if len(fe.emitted) != 0 {
+					t.Fatalf("expected no emit, got %+v", fe.emitted)
+				}
+				return
+			}
+			if len(fe.emitted) != 1 {
+				t.Fatalf("expected 1 emit, got %d", len(fe.emitted))
+			}
+			got := fe.emitted[0]
+			if got.Status != tc.wantStatus {
+				t.Fatalf("status = %q want %q", got.Status, tc.wantStatus)
+			}
+			if got.Service != "fcm" {
+				t.Fatalf("service = %q", got.Service)
+			}
+		})
+	}
+}

--- a/internal/services/fcm/message.go
+++ b/internal/services/fcm/message.go
@@ -32,6 +32,19 @@ func (fcm *FCM) ConvertMessage(data []byte) (smsg services.ServiceMessage, err e
 	if msg.To != "" && len(msg.RegistrationIDs) > 0 {
 		return nil, errors.New("both to/registration_ids specified")
 	}
+	// Strip correlation_id from the raw bytes that get forwarded to FCM.
+	// We re-marshal a generic map after deleting the key. This is cheap
+	// (one push per message) and makes the strip behavior explicit rather
+	// than relying on messaging.Message's silent unknown-field drop.
+	if msg.CorrelationID != "" {
+		var generic map[string]json.RawMessage
+		if err := json.Unmarshal(data, &generic); err == nil {
+			delete(generic, "correlation_id")
+			if stripped, mErr := json.Marshal(generic); mErr == nil {
+				data = stripped
+			}
+		}
+	}
 	msg.rawData = data
 	return msg, nil
 }

--- a/internal/services/fcm/message.go
+++ b/internal/services/fcm/message.go
@@ -10,6 +10,7 @@ import (
 type fcmMessage struct {
 	To              string   `json:"to"`
 	RegistrationIDs []string `json:"registration_ids"`
+	CorrelationID   string   `json:"correlation_id,omitempty"`
 	rawData         []byte
 }
 

--- a/internal/services/fcm/message_test.go
+++ b/internal/services/fcm/message_test.go
@@ -1,6 +1,9 @@
 package fcm
 
-import "testing"
+import (
+	"bytes"
+	"testing"
+)
 
 func TestConvertMessage_CorrelationID(t *testing.T) {
 	cases := []struct {
@@ -31,5 +34,21 @@ func TestConvertMessage_CorrelationID(t *testing.T) {
 				t.Fatalf("CorrelationID = %q, want %q", m.CorrelationID, tc.wantCorr)
 			}
 		})
+	}
+}
+
+func TestConvertMessage_StripsCorrelationIDFromRawData(t *testing.T) {
+	f := &FCM{}
+	body := `{"to":"tok","correlation_id":"9b3f-uuid","notification":{"title":"hi"}}`
+	smsg, err := f.ConvertMessage([]byte(body))
+	if err != nil {
+		t.Fatalf("ConvertMessage: %v", err)
+	}
+	m := smsg.(fcmMessage)
+	if bytes.Contains(m.rawData, []byte("correlation_id")) {
+		t.Fatalf("rawData still contains correlation_id: %s", m.rawData)
+	}
+	if m.CorrelationID != "9b3f-uuid" {
+		t.Fatalf("CorrelationID lost during strip: %q", m.CorrelationID)
 	}
 }

--- a/internal/services/fcm/message_test.go
+++ b/internal/services/fcm/message_test.go
@@ -1,0 +1,35 @@
+package fcm
+
+import "testing"
+
+func TestConvertMessage_CorrelationID(t *testing.T) {
+	cases := []struct {
+		name     string
+		body     string
+		wantCorr string
+	}{
+		{
+			name:     "with correlation_id",
+			body:     `{"to":"tok","correlation_id":"9b3f-uuid","notification":{"title":"hi"}}`,
+			wantCorr: "9b3f-uuid",
+		},
+		{
+			name:     "without correlation_id",
+			body:     `{"to":"tok","notification":{"title":"hi"}}`,
+			wantCorr: "",
+		},
+	}
+	f := &FCM{}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			smsg, err := f.ConvertMessage([]byte(tc.body))
+			if err != nil {
+				t.Fatalf("ConvertMessage: %v", err)
+			}
+			m := smsg.(fcmMessage)
+			if m.CorrelationID != tc.wantCorr {
+				t.Fatalf("CorrelationID = %q, want %q", m.CorrelationID, tc.wantCorr)
+			}
+		})
+	}
+}

--- a/internal/services/fcm/results.go
+++ b/internal/services/fcm/results.go
@@ -1,0 +1,27 @@
+package fcm
+
+import "context"
+
+type ResultStatus string
+
+const (
+	ResultStatusDelivered ResultStatus = "delivered"
+	ResultStatusFailed    ResultStatus = "failed"
+	ResultStatusInvalid   ResultStatus = "invalid"
+)
+
+type ResultEnvelope struct {
+	CorrelationID string
+	Service       string
+	Status        ResultStatus
+	GatewayID     string
+	HTTPStatus    int
+	ErrorCode     string
+	ErrorMessage  string
+	LatencyMS     int64
+	Timestamp     int64
+}
+
+type ResultEmitter interface {
+	Emit(ctx context.Context, r ResultEnvelope) error
+}


### PR DESCRIPTION
## Summary

Plan B of the Vandal push-notification observability initiative (paired with vandalHQ/api#730).

- Optional `correlation_id` field on inbound APNS + FCM envelopes — accepted, parsed, carried through to the handler. Missing field = legacy behavior.
- `correlation_id` is stripped from the FCM raw payload before forwarding to the firebase admin SDK. APNS naturally separates envelope from payload, so it was never a problem there — locked in with a regression test.
- New `queueredis.ResultEmitter` `LPUSH`es a service-agnostic `Result` envelope onto `shove:results` after each gateway round-trip. Models on existing `FeedbackStore`.
- APNS + FCM handlers refactored: `PushMessage` delegates to `pushWithClient` / `sendWithClient` (via new `apns2Pusher` / `fcmSender` interfaces for testability) and classifies each response into `delivered` / `failed` / `invalid` before emitting.
- `cmd/shove/main.go` wires a single `ResultEmitter` (only when Redis is configured) and calls `SetResultEmitter` on APNS production, APNS sandbox, and FCM services.

## Behavior preservation

- Producers that don't send `correlation_id` are unaffected. The emitter short-circuits on empty correlation id, so no result is written.
- In-memory queue mode is unchanged. The emitter is nil in that path and `emitResult` no-ops.
- `shove:feedback` token-invalidity emission is untouched — both `fc.TokenInvalid` calls preserved exactly. The Vandal API will continue to drain `shove:feedback` during rollout, then deprecate that path once `shove:results` is proven.

## Heads-up for monitoring

**FCM `fc.CountPush` is now called on send-error paths.** The pre-existing code used a deferred `CountPush` placed after early returns, so error paths never incremented metrics — a silent metrics drop. The new code aligns FCM with APNS (which always counted errors). Expect the FCM failure counter to start moving in dashboards where it previously stayed flat. This is a strict observability improvement, not a regression.

## Test Plan

- [x] `go test ./...` — 31 passed across 13 packages
- [x] `go build ./...` clean
- [x] APNS end-to-end integration test (queue → handler → emitted result) covers `delivered` / `failed` / `invalid` via miniredis + faked `apns2Pusher`
- [x] FCM unit test against `fcmSender` interface covers `delivered` / `failed` (no E2E integration test; firebase `messaging.Client.Send` isn't easily fakeable without invasive refactoring)
- [ ] Deploy to staging, send a real push via the Vandal API with `correlation_id` set, observe a corresponding entry on `shove:results` (`LRANGE shove:results 0 -1`)
- [ ] Confirm a legacy push without `correlation_id` still delivers and produces no `shove:results` entry
- [ ] Confirm `shove:feedback` still receives `BadDeviceToken`/`Unregistered` events as today

## Follow-ups (out of scope)

- Share one `*goredis.Client` between `FeedbackStore` and `ResultEmitter` instead of two pools to the same Redis (minor cleanliness)
- Async/buffered result emission if Redis ever back-pressures on the hot path (best-effort sync emission is fine today)
- FCM unmarshal-error path could also call `fc.CountPush(false, ...)` for full symmetry with the rest of the new failure paths